### PR TITLE
Enable precompilation.

### DIFF
--- a/src/LispREPL.jl
+++ b/src/LispREPL.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module LispREPL
 
 import Base: LineEdit, REPL


### PR DESCRIPTION
This speeds module loading from:

``` julia
julia> @time eval(:(using LispREPL))
  9.303368 seconds (3.04 M allocations: 139.929 MB, 1.06% gc time)
```

To:

``` julia
julia> @time eval(:(using LispREPL))
  1.761798 seconds (752.66 k allocations: 33.762 MB, 1.26% gc time)
```

First compilation takes about a minute in my PC:

``` julia
julia> @time eval(:(using LispREPL))
INFO: Precompiling module LispREPL...
 55.490583 seconds (1.42 M allocations: 61.507 MB, 0.12% gc time) 
```

This is taking the compilation time of `@time` and `eval` into account, but I don't know hot to avoid confounding in this case.
